### PR TITLE
Bugfix: CommandLineParser allow sourcePort to be set with -sip:port

### DIFF
--- a/LibIReflx/CommandLineParser.cpp
+++ b/LibIReflx/CommandLineParser.cpp
@@ -66,6 +66,7 @@ ThetaStream::CommandLineParser::~CommandLineParser()
 ThetaStream::CommandLineParser::CommandLineParser(const CommandLineParser& other)
 {
 	_pimpl = std::make_unique<ThetaStream::CommandLineParser::Impl>();
+	_pimpl->sourcePort = other.sourcePort();
 	_pimpl->destinationPort = other.destinationPort();
 	_pimpl->ttl = other.ttl();
 	_pimpl->sourceIP = other.sourceIp();


### PR DESCRIPTION
when using -s with ip:port, the listening port remained to be default (50000). 

With this change sourcePort from command line is set correctly.