### PR TITLE
Modern CMake

### DIFF
--- a/IReflx/CMakeLists.txt
+++ b/IReflx/CMakeLists.txt
@@ -18,20 +18,38 @@ target_compile_features(
     PUBLIC cxx_std_14
 )
 
-add_compile_definitions(QSIZE=100)
+target_compile_definitions(IReflx PRIVATE QSIZE=100)
 
-file(GLOB SRC_LIST
-	src/*.cpp)
-
-target_sources(IReflx PRIVATE ${SRC_LIST})
-
-set_property(TARGET IReflx PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_sources(IReflx
+  PUBLIC
+    include/IReflx/CommandLineParser.h
+    include/IReflx/IStarReflextor.h
+  PRIVATE
+    src/BaseIOInterface.cpp
+    src/BaseIOInterface.h
+    src/BoundedBuffer.h
+    src/CommandLineParser.cpp
+    src/GmtiReader.cpp
+    src/GmtiReader.h
+    src/IStarReflextor.cpp
+    src/IStarReflextor.h
+    src/SourceReader.cpp
+    src/SourceReader.h
+    src/StdinReader.cpp
+    src/StdinReader.h
+    src/UdpData.cpp
+    src/UdpData.h
+    src/UdpListener.cpp
+    src/UdpListener.h
+    src/UdpSender.cpp
+    src/UdpSender.h
+)
 
 if(WIN32)
-    set(WS wsock32 ws2_32)
+  target_link_libraries(IReflx wsock32 ws2_32)
+else()
+  target_link_libraries(IReflx)
 endif()
-
-target_link_libraries(IReflx ${WS})
 
 target_include_directories(IReflx
 		PRIVATE src/IReflx

--- a/IReflx/include/IReflx/CommandLineParser.h
+++ b/IReflx/include/IReflx/CommandLineParser.h
@@ -11,6 +11,8 @@ namespace ThetaStream
 		~CommandLineParser();
 		CommandLineParser(const CommandLineParser& other);
 		CommandLineParser& operator=(const CommandLineParser& rhs);
+		CommandLineParser(CommandLineParser&& src) noexcept;
+		CommandLineParser& operator=(CommandLineParser&& rhs) noexcept;
 
 		void parse(int argc, char** argv, const char* appname);
 
@@ -23,8 +25,6 @@ namespace ThetaStream
 		int ttl() const;
 
 	private:
-		void swap(CommandLineParser& other);
-
 		class Impl;
 		std::unique_ptr<Impl> _pimpl;
 	};

--- a/IReflx/src/CommandLineParser.cpp
+++ b/IReflx/src/CommandLineParser.cpp
@@ -16,46 +16,59 @@ const char* opts = "  -s\tSource socket address; otherwise, stdin.\n \
 
 namespace
 {
-	string getip(const char* ip)
-	{
-		string sip(ip);
-		string::size_type pos = sip.find(":");
-		string ret = sip.substr(0, pos);
-		return ret;
-	}
+    string getip(const char* ip)
+    {
+        string sip(ip);
+        string::size_type pos = sip.find(":");
+        string ret = sip.substr(0, pos);
+        return ret;
+    }
 
-	int getport(const char* ip)
-	{
-		string sip(ip);
-		string::size_type pos = sip.find(":");
-		pos++;
-		string port = sip.substr(pos, sip.size() - pos);
-		int ret = atoi(port.c_str());
-		return ret;
-	}
+    int getport(const char* ip)
+    {
+        string sip(ip);
+        string::size_type pos = sip.find(":");
+        pos++;
+        string port = sip.substr(pos, sip.size() - pos);
+        int ret = atoi(port.c_str());
+        return ret;
+    }
 }
 
 namespace ThetaStream
 {
-	class CommandLineParser::Impl
-	{
-	public:
-		Impl() {}
+    class CommandLineParser::Impl
+    {
+    public:
+        Impl() {}
+        ~Impl() {}
+        Impl(const Impl& other)
+            : sourcePort(other.sourcePort)
+            , destinationPort(other.destinationPort)
+            , ttl(other.ttl)
+            , sourceIP(other.sourceIP)
+            , destinationIP(other.destinationIP)
+            , ifaceAddr(other.ifaceAddr)
+            , ofaceAddr(other.ofaceAddr)
+        {
 
-	public:
-		int sourcePort{ 50000 };
-		int destinationPort{ 50000 };
-		int ttl{ 16 };
-		std::string sourceIP{ "-" };
-		std::string destinationIP{ "-" };
-		std::string ifaceAddr;
-		std::string ofaceAddr;
-	};
+        }
+
+
+    public:
+        int sourcePort{ 50000 };
+        int destinationPort{ 50000 };
+        int ttl{ 16 };
+        std::string sourceIP{ "-" };
+        std::string destinationIP{ "-" };
+        std::string ifaceAddr;
+        std::string ofaceAddr;
+    };
 }
 
 ThetaStream::CommandLineParser::CommandLineParser()
 {
-	_pimpl = std::make_unique<ThetaStream::CommandLineParser::Impl>();
+    _pimpl = std::make_unique<ThetaStream::CommandLineParser::Impl>();
 }
 
 ThetaStream::CommandLineParser::~CommandLineParser()
@@ -63,123 +76,174 @@ ThetaStream::CommandLineParser::~CommandLineParser()
 }
 
 ThetaStream::CommandLineParser::CommandLineParser(const CommandLineParser& other)
+    :_pimpl(std::make_unique<ThetaStream::CommandLineParser::Impl>(*other._pimpl))
 {
-	_pimpl = std::make_unique<ThetaStream::CommandLineParser::Impl>();
-	_pimpl->sourcePort = other.sourcePort();
-	_pimpl->destinationPort = other.destinationPort();
-	_pimpl->ttl = other.ttl();
-	_pimpl->sourceIP = other.sourceIp();
-	_pimpl->destinationIP = other.destinationIp();
-	_pimpl->ifaceAddr = other.sourceInterfaceAddress();
-	_pimpl->ofaceAddr = other.destinationInterfaceAddress();
+
 }
 
 ThetaStream::CommandLineParser& ThetaStream::CommandLineParser::operator=(const ThetaStream::CommandLineParser& rhs)
 {
-	ThetaStream::CommandLineParser temp(rhs);
-	swap(temp);
-	return *this;
+    if (this != &rhs)
+    {
+        _pimpl.reset(new ThetaStream::CommandLineParser::Impl(*rhs._pimpl));
+    }
+    return *this;
+}
+
+ThetaStream::CommandLineParser::CommandLineParser(CommandLineParser&& src) noexcept
+{
+    *this = std::move(src);
+}
+
+ThetaStream::CommandLineParser& ThetaStream::CommandLineParser::operator=(CommandLineParser&& rhs) noexcept
+{
+    if (this != &rhs)
+    {
+        _pimpl = std::move(rhs._pimpl);
+    }
+    return *this;
 }
 
 void ThetaStream::CommandLineParser::parse(int argc, char** argv, const char* appname)
 {
-	string source{"-"};
-	string dest{"-"};
-	char c{};
+    string source{ "-" };
+    string dest{ "-" };
+    char c{};
 
-	while (--argc > 0 && (*++argv)[0] == '-')
-	{
-		c = *++argv[0];
-		switch (c)
-		{
-		case 's':
-			source = *argv + 1;
-			break;
-		case 'd':
-			dest = *argv + 1;
-			break;
-		case 'i':
-			_pimpl->ifaceAddr = *argv + 1;
-			break;
-		case 'o':
-			_pimpl->ofaceAddr = *argv + 1;
-		case 't':
-			_pimpl->ttl = std::stoi(*argv + 1);
-			break;
-		case '?':
-		{
-			std::stringstream msg;
-			msg << usage << endl;
-			msg << endl << "Options: " << endl;
-			msg << opts << endl;
-			std::runtime_error exp(msg.str().c_str());
-			throw exp;
-		}
-		default:
-		{
-			std::stringstream msg;
-			msg << appname << ": illegal option " << c << endl;
-			std::runtime_error exp(msg.str().c_str());
-			throw exp;
-		}
-		}
-	}
+    while (--argc > 0 && (*++argv)[0] == '-')
+    {
+        c = *++argv[0];
+        switch (c)
+        {
+        case 's':
+        {
+            // Check for a space character between the option and value
+            if (strlen(*argv + 1) == 0)
+            {
+                source = *++argv;
+                --argc;
+            }
+            else // no space character between the option and value
+            {
+                source = *argv + 1;
+            }
+            break;
+        }
+        case 'd':
+        {
+            if (strlen(*argv + 1) == 0)
+            {
+                dest = *++argv;
+                --argc;
+            }
+            else
+            {
+                dest = *argv + 1;
+            }
+            break;
+        }
+        case 'i':
+        {
+            if (strlen(*argv + 1) == 0)
+            {
+                _pimpl->ifaceAddr = *++argv;
+                --argc;
+            }
+            else
+            {
+                _pimpl->ifaceAddr = *argv + 1;
+            }
+            break;
+        }
+        case 'o':
+        {
+            if (strlen(*argv + 1) == 0)
+            {
+                _pimpl->ofaceAddr = *++argv;
+                --argc;
+            }
+            else
+            {
+                _pimpl->ofaceAddr = *argv + 1;
+            }
+            break;
+        }
+        case 't':
+        {
+            if (strlen(*argv + 1) == 0)
+            {
+                _pimpl->ttl = std::stoi(*++argv);
+                --argc;
+            }
+            else
+            {
+                _pimpl->ttl = std::stoi(*argv + 1);
+            }
+            break;
+        }
+        case '?':
+        {
+            std::stringstream msg;
+            msg << usage << endl;
+            msg << endl << "Options: " << endl;
+            msg << opts << endl;
+            std::runtime_error exp(msg.str().c_str());
+            throw exp;
+        }
+        default:
+        {
+            std::stringstream msg;
+            msg << appname << ": illegal option " << c << endl;
+            std::runtime_error exp(msg.str().c_str());
+            throw exp;
+        }
+        }
+    }
 
-	if (source != "-")
-	{
-		_pimpl->sourceIP = getip(source.c_str());
-		_pimpl->sourcePort = getport(source.c_str());
-	}
+    if (source != "-")
+    {
+        _pimpl->sourceIP = getip(source.c_str());
+        _pimpl->sourcePort = getport(source.c_str());
+    }
 
-	if (dest != "-")
-	{
-		_pimpl->destinationIP = getip(dest.c_str());
-		_pimpl->destinationPort = getport(dest.c_str());
-	}
+    if (dest != "-")
+    {
+        _pimpl->destinationIP = getip(dest.c_str());
+        _pimpl->destinationPort = getport(dest.c_str());
+    }
 }
 
 const char* ThetaStream::CommandLineParser::sourceIp() const
 {
-	return _pimpl->sourceIP.c_str();
+    return _pimpl->sourceIP.c_str();
 }
 
 const char* ThetaStream::CommandLineParser::destinationIp() const
 {
-	return _pimpl->destinationIP.c_str();
+    return _pimpl->destinationIP.c_str();
 }
 
 const char* ThetaStream::CommandLineParser::sourceInterfaceAddress() const
 {
-	return _pimpl->ifaceAddr.c_str();
+    return _pimpl->ifaceAddr.c_str();
 }
 
 const char* ThetaStream::CommandLineParser::destinationInterfaceAddress() const
 {
-	return _pimpl->ofaceAddr.c_str();
+    return _pimpl->ofaceAddr.c_str();
 }
 
 int ThetaStream::CommandLineParser::sourcePort() const
 {
-	return _pimpl->sourcePort;
+    return _pimpl->sourcePort;
 }
 
 int ThetaStream::CommandLineParser::destinationPort() const
 {
-	return _pimpl->destinationPort;
+    return _pimpl->destinationPort;
 }
 
 int ThetaStream::CommandLineParser::ttl() const
 {
-	return _pimpl->ttl;
-}
-
-void ThetaStream::CommandLineParser::swap(ThetaStream::CommandLineParser& other)
-{
-	std::swap(_pimpl->sourcePort, other._pimpl->sourcePort);
-	std::swap(_pimpl->destinationPort, other._pimpl->destinationPort);
-	std::swap(_pimpl->ttl, other._pimpl->ttl);
-	_pimpl->destinationIP.swap(other._pimpl->destinationIP);
-	_pimpl->sourceIP.swap(other._pimpl->sourceIP);
-	_pimpl->ifaceAddr.swap(other._pimpl->ifaceAddr);
-	_pimpl->ofaceAddr.swap(other._pimpl->ofaceAddr);
+    return _pimpl->ttl;
 }

--- a/IReflx/src/CommandLineParser.cpp
+++ b/IReflx/src/CommandLineParser.cpp
@@ -6,7 +6,7 @@
 
 using namespace std;
 
-const char* usage = "Usage: IReflx <OPTIONS>";
+const char* usage = "Usage: IReflxApp <OPTIONS>";
 const char* opts = "  -s\tSource socket address; otherwise, stdin.\n \
  -d\tDestination socket address; otherwise, stdout.\n \
  -t\tTime to Live. (default: 16)\n \


### PR DESCRIPTION
- Follow modern CMake practices.
- Allow space characters between the option and value on the command line.